### PR TITLE
Add 'This Player Name Equals' Statement

### DIFF
--- a/Grimoire.csproj
+++ b/Grimoire.csproj
@@ -330,6 +330,7 @@
     <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdMonsterNotInRoom.cs" />
     <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdMonstersGreaterThan.cs" />
     <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdMonstersLessThan.cs" />
+    <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdNameEquals.cs" />
     <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdNotEquipped.cs" />
     <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdNotHasTarget.cs" />
     <Compile Include="Grimoire\Botting\Commands\Misc\Statements\CmdNotInBank.cs" />

--- a/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
+++ b/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
@@ -23,7 +23,7 @@ namespace Grimoire.Botting.Commands.Misc.Statements
 
         public override string ToString()
         {
-            return "Name Equals " + Value1;
+            return "Player Name Equals: " + Value1;
         }
     }
 }

--- a/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
+++ b/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
@@ -14,7 +14,7 @@ namespace Grimoire.Botting.Commands.Misc.Statements
 
         public Task Execute(IBotEngine instance)
         {
-            if (Player.Username.Equals(instance.IsVar(Value1) ? Configuration.Tempvariable[instance.GetVar(Value1)] : Value1, StringComparison.OrdinalIgnoreCase))
+            if (!(instance.IsVar(Value1)  ? Configuration.Tempvariable[instance.GetVar(Value1)] : Value1).Equals(Player.Username, StringComparison.OrdinalIgnoreCase))
             {
                 instance.Index++;
             }

--- a/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
+++ b/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
@@ -14,7 +14,7 @@ namespace Grimoire.Botting.Commands.Misc.Statements
 
         public Task Execute(IBotEngine instance)
         {
-            if (Player.Username.Equals(instance.IsVar(Value1) ? Configuration.Tempvariable[instance.GetVar(Value1)] : Value1, StringComparison.OrdinalIgnoreCase)
+            if (Player.Username.Equals(instance.IsVar(Value1) ? Configuration.Tempvariable[instance.GetVar(Value1)] : Value1, StringComparison.OrdinalIgnoreCase))
             {
                 instance.Index++;
             }

--- a/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
+++ b/Grimoire/Botting/Commands/Misc/Statements/CmdNameEquals.cs
@@ -1,0 +1,29 @@
+using Grimoire.Game;
+using System;
+using System.Threading.Tasks;
+
+namespace Grimoire.Botting.Commands.Misc.Statements
+{
+    public class CmdNameEquals : StatementCommand, IBotCommand
+    {
+        public CmdNameEquals()
+        {
+            Tag = "This player";
+            Text = "Name Equals";
+        }
+
+        public Task Execute(IBotEngine instance)
+        {
+            if (Player.Username.Equals(instance.IsVar(Value1) ? Configuration.Tempvariable[instance.GetVar(Value1)] : Value1, StringComparison.OrdinalIgnoreCase)
+            {
+                instance.Index++;
+            }
+            return Task.FromResult<object>(null);
+        }
+
+        public override string ToString()
+        {
+            return "Name Equals " + Value1;
+        }
+    }
+}

--- a/Resources/statementcmds.txt
+++ b/Resources/statementcmds.txt
@@ -219,6 +219,12 @@
       "Description1": "Monster count"
     },
     {
+      "$type": "Grimoire.Botting.Commands.Misc.Statements.CmdNameEquals, Grimoire",
+      "Tag": "This Player",
+      "Text": "Name Equals",
+      "Description1": "Player name"
+    }
+    {
       "$type": "Grimoire.Botting.Commands.Misc.Statements.CmdNotInBank, Grimoire",
       "Tag": "Item",
       "Text": "Is not in bank",


### PR DESCRIPTION
Untested as I can't get it to build locally but should be good

Changes:
- "This Player Name Equals" statement

Purpose: some bots use inventory item name's to "recognize" them as player x, y, z, etc. This simplifies those checks by conveniently adding a player name statement. 
